### PR TITLE
mix.exs: Allow Postgrex 0.14.x until we merge upstream's latest

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Scrivener.Ecto.Mixfile do
       {:dialyxir, "~> 0.5.0", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},
       {:ex_doc, "~> 0.18.0", only: :dev},
-      {:postgrex, "~> 0.11.0 or ~> 0.12.0 or ~> 0.13.0", optional: true}
+      {:postgrex, "~> 0.11.0 or ~> 0.12.0 or ~> 0.13.0 or ~> 0.14.0", optional: true}
     ]
   end
 


### PR DESCRIPTION
Upstream has a release that supports Ecto 3.x, but it breaks lots of stuff in Genyes/genyes4 . Temporarily bump just the Postgrex dep to get it to compile. Depended-on-by [PR #194](https://github.com/Genyes/genyes4/pull/194) in Genyes/genyes4